### PR TITLE
Remove announcement (in preparation for announcements collection)

### DIFF
--- a/_includes/announcement.md
+++ b/_includes/announcement.md
@@ -1,7 +1,0 @@
-Join us for a **mesh.101 workshop** this Thursday! We will spend 30 minutes demystifying networking and mesh concepts, cover how to set up the our Raspberry Pi-based reference node, dive into the hardware and software, and discuss why we made certain technology choices and implications to access to our information. We will then move into a one-hour unstructured time where we will play with the mesh devices and discuss specific topics that come up.
-
-The workshop assumes no prior networking or programming knowledge, all are welcome and Robarts is an accessible space.
-
-Thursday **May 5, 2016, 8:30 pm**  
-**Semaphore Demo Room** (1st flr), Robarts, 130 St. George Street  
-OpenStreetMap [directions](http://osm.org/go/ZX6Bw_XP--?m=&way=7991747)

--- a/css/main.scss
+++ b/css/main.scss
@@ -51,7 +51,7 @@ $on-laptop:        800px;
 
 .announcement {
   background-color: #fffbcc;
-  color: #777;
+  color: #555;
   font-size: 0.8em;
   padding: 10px 10px;
 }

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@ title: Toronto Mesh
   <div class="intro-header">
       <h2>We are building a mesh network in Toronto.</h2>
     <div class ="announcement">
-      {% capture vision %}{% include announcement.md %}{% endcapture %}
-      {{ vision | markdownify }}
+      {% capture announcement %}{% include announcement.md %}{% endcapture %}
+      {{ announcement | markdownify }}
     </div> <!-- /.announcement -->
     <div class="intro-message">
       {% capture vision %}{% include vision.md %}{% endcapture %}

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@ title: Toronto Mesh
   <div class="intro-header">
       <h2>We are building a mesh network in Toronto.</h2>
     <div class ="announcement">
-      {% capture announcement %}{% include announcement.md %}{% endcapture %}
-      {{ announcement | markdownify }}
     </div> <!-- /.announcement -->
     <div class="intro-message">
       {% capture vision %}{% include vision.md %}{% endcapture %}

--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@ title: Toronto Mesh
 <div class="home">
   <div class="intro-header">
       <h2>We are building a mesh network in Toronto.</h2>
-    <div class ="announcement">
-    </div> <!-- /.announcement -->
     <div class="intro-message">
       {% capture vision %}{% include vision.md %}{% endcapture %}
       {{ vision | markdownify }}


### PR DESCRIPTION
Per conversation with @garrying, will transition to an announcements [collection](https://jekyllrb.com/docs/collections/) for managing announcements in the future.

Will aim get something WIP up over the weekend, modelled off posts in [Mozilla Labs studyGroup](https://github.com/mozillascience/studyGroup/blob/gh-pages/_includes/portfolio_grid.html)
