### PR TITLE
UTF-8 Build Fix

### DIFF
--- a/scripts/tomesh-build.sh
+++ b/scripts/tomesh-build.sh
@@ -1,4 +1,8 @@
 #! /bin/bash
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 set -e
 
 site="/var/www/tomesh.net/html"


### PR DESCRIPTION
This documents a fix to the daily `tomesh-build.sh` script. `LANG` must be set for a successful build.

Original error: `Error:  Invalid US-ASCII character "\xE2" on line 12`
