### PR TITLE
Jekyll Version Build Script Fix

### DIFF
--- a/scripts/tomesh-build.sh
+++ b/scripts/tomesh-build.sh
@@ -8,4 +8,4 @@ set -e
 site="/var/www/tomesh.net/html"
 source="/var/www/jekyll-hook/tomeshnet/tomesh.net/master/code"
 
-/usr/bin/jekyll build -s $source -d $site
+/usr/local/bin/jekyll build -s $source -d $site


### PR DESCRIPTION
This resolves an issue with the site being built on an old version of jekyll, which resulted in a few event posts not rendering with the correct slug.