### PR TITLE
Travis CI: Exclude self canonical links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 install: gem install jekyll jekyll-paginate html-proofer
 
-script: jekyll build && htmlproofer ./_site
+script: jekyll build && htmlproofer --url-ignore "/www.tomesh.net/,/tomesh.net/" ./_site
 
 notifications:
   email: false


### PR DESCRIPTION
Avoids failures on working branches when new posts/pages are added.