### PR TITLE
a11y & markup edits

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,7 @@
              {% if page.order > 0 %}
                <li>
                  <a class= "nav-item {% if page.url contains current[1] %}active{% endif %}"
-                    href="{{ page.url }}">
+                    href="{{ page.url }}" {% if page.descriptiveTitle %}aria-label="{{ page.descriptiveTitle }}"{% endif %}>
                     {{ page.title }}
                  </a>
                </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
     <h3 class="site-title">
       <a href="{{ site.baseurl }}/" rel="home">
         {% if page.url == '/' %}
-          <img class="site-logo" src="/images/tomesh-icon.svg" alt="{{ site.title }} Logo" //>
+          <img class="site-logo" src="/images/tomesh-icon.svg" alt="{{ site.title }} Logo" />
         {% else %}
           {{ site.title }}
         {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,7 @@
              {% if page.order > 0 %}
                <li>
                  <a class= "nav-item {% if page.url contains current[1] %}active{% endif %}"
-                    href="{{ page.url }}" {% if page.descriptiveTitle %}aria-label="{{ page.descriptiveTitle }}"{% endif %}>
+                    href="{{ page.url }}" aria-label="{% if page.descriptiveTitle %}{{ page.descriptiveTitle }}{% else %}{{ page.title }}{% endif %}">
                     {{ page.title }}
                  </a>
                </li>

--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About
+descriptiveTitle: About Toronto Mesh
 order: 1
 ---
 

--- a/get-involved.md
+++ b/get-involved.md
@@ -19,7 +19,7 @@ Interested? You can start working with us in a few quick steps:
   - The current status of the project is tracked on our publicly-viewable [Kanban board](https://wekan.tomesh.net/b/LWS8X7sGFXqDgZ7ag/tomesh-net) and [GitHub account](https://github.com/tomeshnet)
 
 ## How do I work with you?
-{: #work-with-us}
+{:#work-with-us}
 
 ### Collaborate on our Kanban Board at [wekan.tomesh.net](https://wekan.tomesh.net)
 Toronto Mesh uses a [Kanban (看板)](https://en.wikipedia.org/wiki/Kanban) to keep track of ideas and progress. The software we use is the self-hosted open-source [Wekan](https://github.com/wekan/wekan). Anyone is free to create an account and participate.

--- a/get-involved.md
+++ b/get-involved.md
@@ -18,9 +18,8 @@ Interested? You can start working with us in a few quick steps:
 4. If you have an idea or time to help, [work with us](#work-with-us)
   - The current status of the project is tracked on our publicly-viewable [Kanban board](https://wekan.tomesh.net/b/LWS8X7sGFXqDgZ7ag/tomesh-net) and [GitHub account](https://github.com/tomeshnet)
 
-<a name="work-with-us"></a>
-
 ## How do I work with you?
+{: #work-with-us}
 
 ### Collaborate on our Kanban Board at [wekan.tomesh.net](https://wekan.tomesh.net)
 Toronto Mesh uses a [Kanban (看板)](https://en.wikipedia.org/wiki/Kanban) to keep track of ideas and progress. The software we use is the self-hosted open-source [Wekan](https://github.com/wekan/wekan). Anyone is free to create an account and participate.

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ layout: default
   <div class="container">
     <div class="row featurette-events-row">
       <div class="three columns featurette-events-column">
-        <a href="{{ site.baseurl }}/events" role="link" alt="Toronto Mesh Calendar"><i class="fa fa-calendar fa-5x"></i></a>
+        <a href="{{ site.baseurl }}/events" role="link" title="Toronto Mesh Calendar"><i class="fa fa-calendar fa-5x"></i></a>
       </div>
       <div class="nine columns">
         <h1>Our Next Event</h1>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <div class="content" role="contentinfo">
       <h1>Toronto Mesh</h1>
       <h2>We are building a mesh network in Toronto</h2>
-      <a class="button button-primary" href="{{ site.baseurl }}/about" role="button">Learn More</a>
+      <a class="button button-primary" href="{{ site.baseurl }}/about" aria-label="Learn more about Toronto Mesh" role="button">Learn More</a>
       <br>
     </div>
     <p class="attribution"><a href="https://www.flickr.com/photos/walkingsf/4672190312/" target="_blank">Photo</a> by Eric Fischer / <a href="https://creativecommons.org/licenses/by-sa/2.0/" target="_blank">CC BY-SA</a></p>


### PR DESCRIPTION
- removed header icon unneeded second forward slash
- added `aria-label` and `descriptiveTitle` to pages to be used for more descriptive page links
- removing deprecated `name` attribute
- fixed `alt` attribute on homepage feature row