### PR TITLE
Add Virtual Mesh events for Jan Feb 2017

### DIFF
--- a/_posts/2017-01-19-virtual-mesh.md
+++ b/_posts/2017-01-19-virtual-mesh.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Virtual Mesh Hack Night
+slug: virtual-mesh
+text: Join our virtual mesh from anywhere and play with distributed services.
+location: "#virtualmesh:tomesh.net"
+locationLink: https://chat.tomesh.net/#/room/#virtualmesh:tomesh.net
+date: 2017-01-19
+startTime: '19:00'
+endTime: '23:00'
+---
+
+Some Toronto Mesh members are connected through a virtual mesh network. This is a transitional phase where our mesh nodes are connected to one another using an internet connection instead of a physical line or radio. We are nonetheless able to test out distributed applications as if we are connected through a physical mesh.
+
+Every other Thursday from **7:00 pm ET** on, we meet virtually on [#virtualmesh:tomesh.net](https://chat.tomesh.net/#/room/#virtualmesh:tomesh.net) and do some hands on hacking. This includes running services on our Raspberry Pi platform and testing distributed applications like [IPFS](https://ipfs.io/). If you would like to join, just hop on our chat and say hi!
+
+Although the [cjdns mesh software](https://github.com/cjdelisle/cjdns) runs on multiple platforms, most people are [running it on a Raspberry Pi](https://github.com/tomeshnet/prototype-cjdns-pi2). No matter how you want to join, we will be happy to help you get meshed up.

--- a/_posts/2017-02-02-virtual-mesh.md
+++ b/_posts/2017-02-02-virtual-mesh.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Virtual Mesh Hack Night
+slug: virtual-mesh
+text: Join our virtual mesh from anywhere and play with distributed services.
+location: "#virtualmesh:tomesh.net"
+locationLink: https://chat.tomesh.net/#/room/#virtualmesh:tomesh.net
+date: 2017-02-02
+startTime: '19:00'
+endTime: '23:00'
+---
+
+Some Toronto Mesh members are connected through a virtual mesh network. This is a transitional phase where our mesh nodes are connected to one another using an internet connection instead of a physical line or radio. We are nonetheless able to test out distributed applications as if we are connected through a physical mesh.
+
+Every other Thursday from **7:00 pm ET** on, we meet virtually on [#virtualmesh:tomesh.net](https://chat.tomesh.net/#/room/#virtualmesh:tomesh.net) and do some hands on hacking. This includes running services on our Raspberry Pi platform and testing distributed applications like [IPFS](https://ipfs.io/). If you would like to join, just hop on our chat and say hi!
+
+Although the [cjdns mesh software](https://github.com/cjdelisle/cjdns) runs on multiple platforms, most people are [running it on a Raspberry Pi](https://github.com/tomeshnet/prototype-cjdns-pi2). No matter how you want to join, we will be happy to help you get meshed up.

--- a/_posts/2017-02-16-virtual-mesh.md
+++ b/_posts/2017-02-16-virtual-mesh.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Virtual Mesh Hack Night
+slug: virtual-mesh
+text: Join our virtual mesh from anywhere and play with distributed services.
+location: "#virtualmesh:tomesh.net"
+locationLink: https://chat.tomesh.net/#/room/#virtualmesh:tomesh.net
+date: 2017-02-16
+startTime: '19:00'
+endTime: '23:00'
+---
+
+Some Toronto Mesh members are connected through a virtual mesh network. This is a transitional phase where our mesh nodes are connected to one another using an internet connection instead of a physical line or radio. We are nonetheless able to test out distributed applications as if we are connected through a physical mesh.
+
+Every other Thursday from **7:00 pm ET** on, we meet virtually on [#virtualmesh:tomesh.net](https://chat.tomesh.net/#/room/#virtualmesh:tomesh.net) and do some hands on hacking. This includes running services on our Raspberry Pi platform and testing distributed applications like [IPFS](https://ipfs.io/). If you would like to join, just hop on our chat and say hi!
+
+Although the [cjdns mesh software](https://github.com/cjdelisle/cjdns) runs on multiple platforms, most people are [running it on a Raspberry Pi](https://github.com/tomeshnet/prototype-cjdns-pi2). No matter how you want to join, we will be happy to help you get meshed up.


### PR DESCRIPTION
Add virtual mesh to calendar for first two months of 2017. I pushed it back by an hour (to 7pm) as that seems more convenient for people. The origin reason for making it early was to bridge with Paris, but 6pm was still too late to connect, so let's move back to this later time.

Another thing we can start is to arrange local meet-ups, so people can optionally virtual mesh in-person. Perhaps the post-conf gathering @ansuz suggested can be just a virtual mesh meet-up?