### PR TITLE
Fix Show More padding and height transition

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -107,6 +107,7 @@
   @media screen and (max-width: $on-palm) {
     height: auto;
     margin-bottom: 1.5em;
+    padding-right: 0;
   }
 }
 
@@ -161,6 +162,15 @@
     max-height: 100vh;
     -webkit-transition: max-height 1s;
     transition: max-height 1s;
+
+    @media screen and (max-width: $on-palm) {
+      display: block;
+      max-height: none;
+    }
+  }
+
+  @media screen and (max-width: $on-palm) {
+    display: none;
   }
 }
 


### PR DESCRIPTION
There's an issue with the show/hide transition on small viewports with content getting cut off (see screenshot). This opts for removing the transition on mobile and fixes a spacing issue with event items.
![simulator screen shot feb 27 2017 9 20 04 pm](https://cloud.githubusercontent.com/assets/227587/23389800/4b231fd6-fd38-11e6-92cf-32f5d1536715.png)
