### PR TITLE
Dat keep files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ future: true # for events set in the future to show up
 # Excluded folders
 exclude: [Gemfile, Gemfile.lock, scripts, vendor]
 
+# Keep files (Dat files)
+keep_files: [dat.json, .dat, .well-known]
+
 # Events pagination
 paginate: 8
 paginate_path: "events/page-:num"

--- a/dat.json
+++ b/dat.json
@@ -1,0 +1,5 @@
+{
+  "title": "Toronto Mesh",
+  "author": "Toronto Mesh <hello@tomesh.net>",
+  "description": "We are building a mesh network in Toronto"
+}


### PR DESCRIPTION
- Ignore `.dat` and `dathttpd` from `jekyll build` directory wipe
- adds `dat.json` at the top-level for archive meta