### PR TITLE
Google Map Positioning

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,8 @@
 
   {{ content }}
 
-  {% include footer.html %}
+  {% if page.layout_footer != false %}
+    {% include footer.html %}
+  {% endif %}
 </body>
 </html>

--- a/map.html
+++ b/map.html
@@ -2,18 +2,8 @@
 layout: default
 title: Map
 order: 2
+layout_footer: false
 ---
-<style>
-/* Hacks to allow better interaction with google maps and the mouse*/
-.site-footer {
-    top:100%;
-    width:100%;
-    position:absolute;
-}
-#map {
-    position:absolute;
-}
-</style>
 <div id="map">
   <div id="map_canvas"></div>
 </div>

--- a/map.html
+++ b/map.html
@@ -3,6 +3,17 @@ layout: default
 title: Map
 order: 2
 ---
+<style>
+/* Hacks to allow better interaction with google maps and the mouse*/
+.site-footer {
+    top:100%;
+    width:100%;
+    position:absolute;
+}
+#map {
+    position:absolute;
+}
+</style>
 <div id="map">
   <div id="map_canvas"></div>
 </div>


### PR DESCRIPTION
CSS Hack to allow google map interface to work like "natural" and  prevent things like  require  CTRL+SCROLL to zoom.

Scroll bar still allows for the scrolling of the page as do arrows to see footer.

Please confirm on your os/browser of choice if there are any issues. 