### PR TITLE
Remote Markdown: UTF-8 BOM fix

### DIFF
--- a/_plugins/remote_markdown.rb
+++ b/_plugins/remote_markdown.rb
@@ -24,6 +24,7 @@ module Jekyll
       fail 'resource unavailable' unless res.is_a?(Net::HTTPSuccess)
 
       @content = content_blobber(uri, res).force_encoding('UTF-8')
+                                          .sub("\xEF\xBB\xBF", '')
     end
 
     def render(_context)


### PR DESCRIPTION
- https://github.com/tomeshnet/prototype-cjdns-pi/blob/master/README.md is encoded in UTF-8 with [BOM](https://en.wikipedia.org/wiki/Byte_order_mark), which is causing the page title to not render properly (shows up as `# prototype-cjdns-pi` instead of a heading)
- Adding search/replace to remove BOM for UTF-8 files