### PR TITLE
Changes the link for the chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you notice any errors or would like to submit changes or add content to our w
 In addition, you can provide feedback by:
 * adding a comment to the [issue tracker](https://github.com/tomeshnet/tomesh.net/issues)
 * emailing us at [hello@tomesh.net](mailto:hello@tomesh.net)
-* speaking with us on our chat at [`#tomesh:chat.tomesh.net`](https://chat.tomesh.net/#/room/#tomesh:tomesh.net)
+* speaking with us on our chat at [`#tomesh:chat.tomesh.net`](https://chat.tomesh.net/#/group/+tomesh:tomesh.net)
 
 ## Content
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you notice any errors or would like to submit changes or add content to our w
 In addition, you can provide feedback by:
 * adding a comment to the [issue tracker](https://github.com/tomeshnet/tomesh.net/issues)
 * emailing us at [hello@tomesh.net](mailto:hello@tomesh.net)
-* speaking with us on our chat at [`#tomesh:chat.tomesh.net`](https://chat.tomesh.net/#/group/+tomesh:tomesh.net)
+* speaking with us on our chat at [`+tomesh:tomesh.net`](https://chat.tomesh.net/#/group/+tomesh:tomesh.net)
 
 ## Content
 

--- a/_includes/icon-matrix.html
+++ b/_includes/icon-matrix.html
@@ -1,4 +1,4 @@
-<a href="https://chat.tomesh.net/#/room/#tomesh:tomesh.net" rel="noopener" target="_blank">
+<a href="https://chat.tomesh.net/#/group/+tomesh:tomesh.net" rel="noopener" target="_blank">
   {% include_absolute _icons/comments.svg class:icon %}
-  <span class="service-name">#tomesh:tomesh.net</span>
+  <span class="service-name">+tomesh:tomesh.net</span>
 </a>

--- a/projects.md
+++ b/projects.md
@@ -39,7 +39,7 @@ The Prototype Node now supports many single-board computers (SBCs) for similar u
 - [cjdns](https://github.com/cjdelisle/cjdns)
 - [InterPlanetary File System](https://ipfs.io/) (IPFS)
 - [Secure Scuttlebutt](https://github.com/ssbc/secure-scuttlebutt) (SSB)
-- Network monitoring and configuration tools ([Grafana](https://grafana.com/) and [Prometheus](https://prometheus.io/), among others) 
+- Network monitoring and configuration tools ([Grafana](https://grafana.com/) and [Prometheus](https://prometheus.io/), among others)
 
 **Status:** Always in Beta  
 This project will keep being actively developed to support ongoing research work and experimentation. It has been forked by many groups for their own single-board computer mesh network projects.
@@ -124,7 +124,7 @@ Visit our chat {% include icon-matrix.html %} or attend a [meetup](/events/) to 
 An open-source syllabus that aims to provide hands-on training and social context of decentralized systems, including mesh networks and peer-to-peer applications.  
 Each session in the syllabus can be offered as a stand-alone module.
 
-We have completed one full series at the Toronto Public Library. 
+We have completed one full series at the Toronto Public Library.
 
 **Status:** Beta  
 Efforts are underway to improve reproducibility and packaging.
@@ -169,7 +169,7 @@ Visit the [Tools Transfer Guide](https://github.com/tomeshnet/documents/blob/mas
 
 ### Meshbot
 
-The chatbot our Matrix [chat](https://chat.tomesh.net/#/room/#tomesh:tomesh.net) uses to send event reminders and answer basic questions about the mesh.
+The chatbot our Matrix [chat](https://chat.tomesh.net/#/group/+tomesh:tomesh.net) uses to send event reminders and answer basic questions about the mesh.
 
 **Status:** Production (live)
 


### PR DESCRIPTION
The communities feature finally works on our server!  We should really make use of it at this point because it is the way Riot is supposed to be used (if I have understood their [re-design](https://medium.com/@dharmaone/redesigning-matrix-riot-chat-c7bffd9eb841) correctly anyways).

This PR changes the links of the Riot chat on our website to use https://chat.tomesh.net/#/group/+tomesh:tomesh.net instead of the tomesh chat room itself.  This shows users all of our rooms and lets them join with a single click.