### PR TITLE
Past Event Missing Fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ include: [.well-known]
 keep_files: [.dat]
 
 # Events pagination
-paginate: 8
+paginate: 10
 paginate_path: "events/page-:num"
 
 # Jekyll gems

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -103,9 +103,11 @@
 .event-item {
   padding-right: 20px;
   margin: 0 0 40px;
+  max-height: 142px;
 
   @media screen and (max-width: $on-palm) {
     height: auto;
+    max-height: auto;
     margin-bottom: 1.5em;
     padding-right: 0;
   }


### PR DESCRIPTION
The event page currently loads 8 events and splits them up between past and present. 
Should be 8 for past and 8 for present.

Currently there are 8 "future" events scheduled and therefore it states there are currently no previous events

Increasing paginate to 10 is a work-around but will allow for some events to be displayed.

![image](https://user-images.githubusercontent.com/29005789/74094346-a8cc9980-4aad-11ea-96db-cb35b2adc9aa.png)