### PR TITLE
Update icon-slack.html

### DIFF
--- a/_includes/icon-slack.html
+++ b/_includes/icon-slack.html
@@ -1,4 +1,4 @@
-<a href="https://civictechto-slack-invite.herokuapp.com/" target="_blank" data-proofer-ignore>
+<a href="https://join.slack.com/t/tomeshnet/shared_invite/zt-fjse2gtj-OHpd5GopAqIrddmaGuZoug" target="_blank" data-proofer-ignore>
   {% include_absolute _icons/slack.svg class:icon %}
-  <span class="service-name">#tomesh on CivicTechTO's slack</span>
+  <span class="service-name">#tomesh on slack</span>
 </a>


### PR DESCRIPTION
Correct link to slack bridge

Link was pointing to an old one that is very outdated
![image](https://user-images.githubusercontent.com/29005789/87988371-32957f80-caae-11ea-8a68-4261e700c7a6.png)

