### PR TITLE
Remove build a node

### DIFF
--- a/build-a-node.md
+++ b/build-a-node.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: Build A Node
-parent: Get Involved
-order: 1
----
-{% remote_markdown https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi/master/README.md %}


### PR DESCRIPTION
Since the focus is no longer cjdns remove this from the website.

Perhaps it should be replaced with a "get connected" page. For now would be very vague, like contact hello.

not sure if it worth putting it up for now.