### PR TITLE
Wrap Formated Code

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -100,6 +100,6 @@ pre {
     display: block;
     border: 0;
     padding: 1rem 0;
-    white-space: pre;
+    white-space: pre-wrap;
   }
 }


### PR DESCRIPTION
I don't think we use code blocks for actual code anywhere on the site

Change will turn current unwrapped blocks
![image](https://user-images.githubusercontent.com/29005789/94750253-a1674280-0353-11eb-895c-25a0a6dd848d.png)

into readable wrapped

![image](https://user-images.githubusercontent.com/29005789/94750227-96acad80-0353-11eb-82fa-52af08fcf73e.png)


