### PR TITLE
Better initial center of toronto

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -44,7 +44,7 @@ function initialize() {
   //Prepare default view and create map
   var mapOptions = {
     zoom: 12,
-    center: new google.maps.LatLng(43.698136, -79.397593),
+    center: new google.maps.LatLng(43.72 -79.33),
     mapTypeId: google.maps.MapTypeId.ROADMAP,
     fullscreenControl: false,
     mapTypeControl: true,


### PR DESCRIPTION
Map right now centers a little to far west. New co-ord should show both supernodes without needing to pan when first launched